### PR TITLE
docs: reconcile docs with reality + add NuGet distribution plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Two of the seven diagnostics come with IDE code fixes:
 
 ### ⚡ Quick Install
 
+> **Availability:** SimplicityTools is not on NuGet.org yet. The install commands and version badges below become valid once the matching release tag (`libraries/vX.Y.Z`, `analyzers/vX.Y.Z`, `cli/vX.Y.Z`) is published. Until then, [build from source](#get-started) or follow the [distribution plan](docs/distribution-plan.md). The badges self-update on first publish.
+
 | Package | Latest | Install |
 | --- | --- | --- |
 | **Cli** (global tool) | [![NuGet](https://img.shields.io/nuget/v/SimplicityTools.Cli.svg?logo=nuget)](https://www.nuget.org/packages/SimplicityTools.Cli/) | `dotnet tool install --global SimplicityTools.Cli` |
@@ -83,7 +85,7 @@ Two of the seven diagnostics come with IDE code fixes:
 
 ### Get Started
 
-1. **Install the global tool** (when published):
+1. **Install the global tool** (once published — see [availability](#-quick-install)):
    ```bash
    dotnet tool install --global SimplicityTools.Cli
    dotnet simplicity analyze path/to/YourSolution.sln

--- a/docs/SimplicityFirst_DotNet_Toolkit_AI_Implementation.md
+++ b/docs/SimplicityFirst_DotNet_Toolkit_AI_Implementation.md
@@ -283,7 +283,7 @@ public sealed class SingleImplementationInterfaceAnalyzer : DiagnosticAnalyzer
         category:           "SimplicityFirst.HalfRule",
         defaultSeverity:    DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri:        "https://simplicity-first.dev/analyzers/SF0001");
+        helpLinkUri:        "https://simplicitytools.dev/analyzers/sf0001");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);
@@ -313,7 +313,7 @@ Each fix provider lives in `src/SimplicityTools.Analyzers/CodeFixes/` and follow
 
 ### 4.4 Help Link URLs
 
-All analyzers point to `https://simplicity-first.dev/analyzers/SF000X` where X is the analyzer number. The pages do not need to exist for shipping (404 is acceptable in v1).
+All analyzers point to `https://simplicitytools.dev/analyzers/sf000x` where x is the analyzer number (lowercase). These pages are live on the docs site.
 
 ---
 

--- a/docs/SimplicityFirst_DotNet_Toolkit_AI_Implementation.md
+++ b/docs/SimplicityFirst_DotNet_Toolkit_AI_Implementation.md
@@ -283,7 +283,7 @@ public sealed class SingleImplementationInterfaceAnalyzer : DiagnosticAnalyzer
         category:           "SimplicityFirst.HalfRule",
         defaultSeverity:    DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri:        "https://simplicitytools.dev/analyzers/sf0001");
+        helpLinkUri:        "https://simplicitytools.dev/analyzers/sf0001/");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);
@@ -313,7 +313,7 @@ Each fix provider lives in `src/SimplicityTools.Analyzers/CodeFixes/` and follow
 
 ### 4.4 Help Link URLs
 
-All analyzers point to `https://simplicitytools.dev/analyzers/sf000x` where x is the analyzer number (lowercase). These pages are live on the docs site.
+All analyzers point to `https://simplicitytools.dev/analyzers/sf000x/` where x is the analyzer number (lowercase). These pages are live on the docs site.
 
 ---
 

--- a/docs/distribution-plan.md
+++ b/docs/distribution-plan.md
@@ -1,0 +1,82 @@
+# SimplicityTools Distribution Plan
+
+**Status:** First public release of `0.4.0` (never shipped) + ongoing strategy.
+**Audience:** Maintainers/operators cutting releases.
+**Companion:** Pre-publish blockers are tracked in [`CODEBASE_REVIEW_2026-05-28.md`](CODEBASE_REVIEW_2026-05-28.md); release mechanics in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+SimplicityTools ships five NuGet packages in three independently tagged release groups:
+
+| Release group | Tag | Packages |
+| --- | --- | --- |
+| Shared libraries | `libraries/vX.Y.Z` | `SimplicityTools.Metrics`, `SimplicityTools.Filters`, `SimplicityTools.Tca` |
+| Analyzers | `analyzers/vX.Y.Z` | `SimplicityTools.Analyzers` |
+| CLI | `cli/vX.Y.Z` | `SimplicityTools.Cli` (`dotnet-simplicity` global tool) |
+
+The canonical version baseline is `SimplicityToolsReleaseVersion` in `Directory.Build.props` (currently `0.4.0`).
+
+---
+
+## 1. Pre-publish gate (must be GREEN before any real tag)
+
+Treat the 2026-05-28 review's blockers as open. Do not push a stable tag until all pass:
+
+- [ ] Clean build, zero warnings (including CS8604 in Analyzers):
+  `dotnet build SimplicityTools.sln --nologo --verbosity minimal`
+- [ ] Full test suite green (Sample.Simplified baseline, CLI P95 perf gate):
+  `dotnet test SimplicityTools.sln --nologo --no-build --verbosity minimal`
+- [ ] Analyzer package consumer validation: pack, reference from a scratch project with `PrivateAssets="all"`, confirm at least one `SF000x` diagnostic loads and **no** `lib/` compile assets or NuGet dependencies leak downstream.
+- [ ] CLI packaged smoke test: install from a local feed, then
+  `dotnet simplicity analyze ./samples/Sample.Simplified/Sample.Simplified.sln` succeeds.
+- [ ] Docs reconciled: no `simplicity-first.dev` links in `src/` or `docs/`; no `dotnet simplicity snapshot`; README states pre-launch availability.
+
+Go/No-Go: any unchecked box = NO-GO.
+
+## 2. Publishing mechanics
+
+- **Secret:** `NUGET_API_KEY` stored in repo Actions secrets. Use a key scoped to the `SimplicityTools.*` package glob with a finite expiry; rotate after first release.
+- **Version source:** `Directory.Build.props` sets the baseline; the pushed tag's SemVer is authoritative at publish time. Local `dotnet pack` defaults to `<version>-local`.
+- **Tag -> publish:** `nuget-publish.yml` reads the SemVer from the tag, validates the matching package group, and publishes `.nupkg` + `.snupkg` to NuGet.org. Branch pushes only produce `-ci.<run>` validation artifacts.
+- **Validation dry-run:** Actions -> NuGet release pipeline -> Run workflow with `release_group=validation` to exercise pack/validate without publishing.
+- **Prerelease first:** because this is the first-ever publish, ship `0.4.0-preview.1` (or `-rc.1`) per group first to prove the live pipeline and install UX, then the bare `0.4.0` stable.
+
+## 3. User install paths + post-publish smoke tests
+
+### 3.1 Global CLI tool
+```bash
+dotnet tool install --global SimplicityTools.Cli
+dotnet simplicity analyze path/to/YourSolution.sln
+```
+Smoke test after publish: install on a clean machine/container, run `analyze` on `Sample.Simplified`, confirm exit 0 and a metrics summary.
+
+### 3.2 Libraries
+```bash
+dotnet add package SimplicityTools.Metrics   # + Filters / Tca as needed (version together)
+```
+Smoke test: a scratch console app calls `await new SimplicityCollector().CollectAsync("...sln")` and prints `snapshot.ToSummary()`.
+
+### 3.3 Analyzers
+```xml
+<PackageReference Include="SimplicityTools.Analyzers" Version="x.y.z" PrivateAssets="all" />
+```
+Smoke test: build a scratch project that references it and confirm an `SF000x` warning appears in build output, with no added compile/runtime assets in the consumer graph.
+
+## 4. First-release runbook (ordered)
+
+1. Confirm the section 1 gate is fully GREEN.
+2. Confirm `SimplicityToolsReleaseVersion` is `0.4.0`.
+3. (Optional) Run the `validation` workflow dispatch; confirm artifacts build.
+4. Push **prerelease** tags, libraries first (dependency root):
+   `git tag libraries/v0.4.0-preview.1 && git push origin libraries/v0.4.0-preview.1`
+   then `analyzers/v0.4.0-preview.1`, then `cli/v0.4.0-preview.1`.
+5. After each publish, verify on NuGet.org and run the matching section 3 smoke test.
+6. When prerelease is validated, push **stable** tags in the same order:
+   `libraries/v0.4.0` -> `analyzers/v0.4.0` -> `cli/v0.4.0`.
+7. Re-run all three smoke tests against the stable packages.
+8. Announce (README badges go live automatically; update CHANGELOG).
+
+## 5. Ongoing strategy
+
+- **SemVer policy:** patch (`x.y.Z`) = additive/safe; minor (`x.Y.z`) = new metrics/rules — evaluate before upgrading; major (`X.y.z`) = breaking API. `Metrics`/`Filters`/`Tca` always version together; `Analyzers` and `Cli` move on their own cadence.
+- **Prerelease channel:** publish `-preview.N`/`-rc.N` for any change touching the published API surface or the analyzer package layout before the stable tag.
+- **Changelog:** maintain `CHANGELOG.md` with one section per release group and version.
+- **Bad publish:** NuGet packages are immutable — never attempt deletion. Unlist the broken version and publish a fixed patch.

--- a/docs/distribution-plan.md
+++ b/docs/distribution-plan.md
@@ -24,9 +24,8 @@ Treat the 2026-05-28 review's blockers as open. Do not push a stable tag until a
   `dotnet build SimplicityTools.sln --nologo --verbosity minimal`
 - [ ] Full test suite green (Sample.Simplified baseline, CLI P95 perf gate):
   `dotnet test SimplicityTools.sln --nologo --no-build --verbosity minimal`
-- [ ] Analyzer package consumer validation: pack, reference from a scratch project with `PrivateAssets="all"`, confirm at least one `SF000x` diagnostic loads and **no** `lib/` compile assets or NuGet dependencies leak downstream.
-- [ ] CLI packaged smoke test: install from a local feed, then
-  `dotnet simplicity analyze ./samples/Sample.Simplified/Sample.Simplified.sln` succeeds.
+- [ ] Analyzer package consumer validation: pack, reference from a scratch project with `PrivateAssets="all"`, confirm at least one `SF000x` diagnostic loads and **no** `lib/` compile assets or NuGet dependencies leak downstream. The package must set `<developmentDependency>true</developmentDependency>`. See the local-feed steps in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+- [ ] CLI packaged smoke test: pack and install from a local folder feed (`dotnet tool install --global SimplicityTools.Cli --add-source ./artifacts/local-feed --version <version>-local`; see [`../CONTRIBUTING.md`](../CONTRIBUTING.md)), then `dotnet simplicity analyze ./samples/Sample.Simplified/Sample.Simplified.sln` succeeds.
 - [ ] Docs reconciled: no `simplicity-first.dev` links in `src/` or `docs/`; no `dotnet simplicity snapshot`; README states pre-launch availability.
 
 Go/No-Go: any unchecked box = NO-GO.

--- a/docs/distribution-plan.md
+++ b/docs/distribution-plan.md
@@ -24,7 +24,7 @@ Treat the 2026-05-28 review's blockers as open. Do not push a stable tag until a
   `dotnet build SimplicityTools.sln --nologo --verbosity minimal`
 - [ ] Full test suite green (Sample.Simplified baseline, CLI P95 perf gate):
   `dotnet test SimplicityTools.sln --nologo --no-build --verbosity minimal`
-- [ ] Analyzer package consumer validation: pack, reference from a scratch project with `PrivateAssets="all"`, confirm at least one `SF000x` diagnostic loads and **no** `lib/` compile assets or NuGet dependencies leak downstream. The package must set `<developmentDependency>true</developmentDependency>`. See the local-feed steps in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+- [ ] Analyzer package consumer validation: pack, reference from a scratch project with `PrivateAssets="all"`, confirm at least one `SF000x` diagnostic loads and **no** `lib/` compile assets or NuGet dependencies leak downstream. The package must set `<developmentDependency>true</developmentDependency>` (already set in the analyzer .csproj). See the local-feed steps in [../CONTRIBUTING.md](../CONTRIBUTING.md).
 - [ ] CLI packaged smoke test: pack and install from a local folder feed (`dotnet tool install --global SimplicityTools.Cli --add-source ./artifacts/local-feed --version <version>-local`; see [`../CONTRIBUTING.md`](../CONTRIBUTING.md)), then `dotnet simplicity analyze ./samples/Sample.Simplified/Sample.Simplified.sln` succeeds.
 - [ ] Docs reconciled: no `simplicity-first.dev` links in `src/` or `docs/`; no `dotnet simplicity snapshot`; README states pre-launch availability.
 

--- a/docs/superpowers/plans/2026-06-08-nuget-distribution.md
+++ b/docs/superpowers/plans/2026-06-08-nuget-distribution.md
@@ -1,0 +1,410 @@
+# NuGet Distribution & Doc Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile SimplicityTools' docs/code with reality (dead analyzer help links, a nonexistent CLI command, pre-launch install claims) and produce a first-public-release runbook for shipping 0.4.0 to NuGet.org plus an ongoing versioning strategy.
+
+**Architecture:** Two deliverables. (1) Targeted drift fixes across seven analyzer source files, one docs file, and README. (2) A new standalone operator doc `docs/distribution-plan.md`. No application logic changes; "tests" here are grep/build/link verification commands. Work happens on branch `docs/nuget-distribution-plan` (already created; the design spec is already committed there).
+
+**Tech Stack:** .NET 10 / Roslyn analyzers (netstandard2.0), Markdown docs, Astro docs-site (`docs-site/src/pages/analyzers/sf000x.astro` are the live help-link targets), GitHub Actions (`.github/workflows/nuget-publish.yml`).
+
+**Verified facts this plan relies on:**
+- Real CLI commands: `analyze`, `report`, `baseline`, `diff`, `budget`, `watch`. No `snapshot`.
+- `dotnet simplicity baseline <sln>` writes `.simplicity-baseline.json` next to the solution.
+- `dotnet simplicity report <sln>` reads `.simplicity-history/*.json` for trends and writes `./simplicity-report/index.html`.
+- 7 analyzers set `helpLinkUri: "https://simplicity-first.dev/analyzers/SF000X"` (404). Live routes: `https://simplicitytools.dev/analyzers/sf000x` (lowercase).
+- Nothing is on NuGet; no git tags; version `0.4.0` in `Directory.Build.props`.
+
+---
+
+## File Structure
+
+**Modify (code — analyzer help links):**
+- `src/SimplicityTools.Analyzers/SingleImplementationInterfaceAnalyzer.cs` (SF0001)
+- `src/SimplicityTools.Analyzers/UnusedDependencyAnalyzer.cs` (SF0002)
+- `src/SimplicityTools.Analyzers/HighComplexityAnalyzer.cs` (SF0003)
+- `src/SimplicityTools.Analyzers/AbstractionLayerDepthAnalyzer.cs` (SF0004)
+- `src/SimplicityTools.Analyzers/ConstructorParameterCountAnalyzer.cs` (SF0005)
+- `src/SimplicityTools.Analyzers/SingleSpecializationGenericParameterAnalyzer.cs` (SF0006)
+- `src/SimplicityTools.Analyzers/NonPrimaryPathOverReferencedAnalyzer.cs` (SF0007)
+
+**Modify (docs):**
+- `docs/using-the-simplicity-tools.md` (~line 917 — `snapshot` → `baseline` + copy)
+- `README.md` (Quick Install / Get Started — pre-launch honesty + correct snippets)
+
+**Create:**
+- `docs/distribution-plan.md` (the new operator runbook, spec §4)
+
+---
+
+## Task 1: Retarget analyzer help links to the live docs site
+
+**Files:**
+- Modify: all 7 analyzer `.cs` files listed above
+
+- [ ] **Step 1: Verify the current dead links (baseline)**
+
+Run:
+```bash
+grep -rn "simplicity-first.dev" src/SimplicityTools.Analyzers/
+```
+Expected: 7 lines, one per analyzer, each `helpLinkUri: "https://simplicity-first.dev/analyzers/SF000X",`
+
+- [ ] **Step 2: Replace all dead help-link hosts in one sweep**
+
+The path segment case must change from `SF000X` (uppercase) to `sf000x` (lowercase) to match the live Astro routes. Run a per-file `sed` so each ID is lowercased correctly:
+```bash
+cd src/SimplicityTools.Analyzers
+sed -i '' 's#https://simplicity-first.dev/analyzers/SF0001#https://simplicitytools.dev/analyzers/sf0001#' SingleImplementationInterfaceAnalyzer.cs
+sed -i '' 's#https://simplicity-first.dev/analyzers/SF0002#https://simplicitytools.dev/analyzers/sf0002#' UnusedDependencyAnalyzer.cs
+sed -i '' 's#https://simplicity-first.dev/analyzers/SF0003#https://simplicitytools.dev/analyzers/sf0003#' HighComplexityAnalyzer.cs
+sed -i '' 's#https://simplicity-first.dev/analyzers/SF0004#https://simplicitytools.dev/analyzers/sf0004#' AbstractionLayerDepthAnalyzer.cs
+sed -i '' 's#https://simplicity-first.dev/analyzers/SF0005#https://simplicitytools.dev/analyzers/sf0005#' ConstructorParameterCountAnalyzer.cs
+sed -i '' 's#https://simplicity-first.dev/analyzers/SF0006#https://simplicitytools.dev/analyzers/sf0006#' SingleSpecializationGenericParameterAnalyzer.cs
+sed -i '' 's#https://simplicity-first.dev/analyzers/SF0007#https://simplicitytools.dev/analyzers/sf0007#' NonPrimaryPathOverReferencedAnalyzer.cs
+cd ../..
+```
+(Note: `sed -i ''` is the BSD/macOS form. On Linux use `sed -i`.)
+
+- [ ] **Step 3: Verify no dead host remains and routes are lowercase**
+
+Run:
+```bash
+grep -rn "simplicity-first.dev" src/SimplicityTools.Analyzers/   # expect: no output
+grep -rn "simplicitytools.dev/analyzers/sf000" src/SimplicityTools.Analyzers/ | wc -l   # expect: 7
+```
+Confirm each target route file exists in the site:
+```bash
+for n in 1 2 3 4 5 6 7; do test -f docs-site/src/pages/analyzers/sf000$n.astro && echo "sf000$n OK"; done
+```
+Expected: `sf0001 OK` … `sf0007 OK`.
+
+- [ ] **Step 4: Build the analyzers project to confirm the edits compile**
+
+Run:
+```bash
+dotnet build src/SimplicityTools.Analyzers/SimplicityTools.Analyzers.csproj --nologo --verbosity quiet
+```
+Expected: Build succeeded. (Pre-existing CS8604 warnings from the review may still appear; they are gated separately and are not introduced by this task.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/SimplicityTools.Analyzers/*.cs
+git commit -m "fix(analyzers): retarget SF0001-SF0007 help links to simplicitytools.dev"
+```
+
+---
+
+## Task 2: Remove the nonexistent `dotnet simplicity snapshot` command from docs
+
+**Files:**
+- Modify: `docs/using-the-simplicity-tools.md` (~line 917)
+
+- [ ] **Step 1: Confirm the single offending reference**
+
+Run:
+```bash
+grep -rn "simplicity snapshot" docs/ README.md | grep -v CODEBASE_REVIEW
+```
+Expected: exactly one hit — `docs/using-the-simplicity-tools.md:917`.
+
+- [ ] **Step 2: Replace the snapshot step with the real baseline+copy flow**
+
+In `docs/using-the-simplicity-tools.md`, find this block:
+```yaml
+- name: Save snapshot for trends
+  run: |
+    mkdir -p .simplicity-history
+    cp $(dotnet simplicity snapshot YourSolution.sln) .simplicity-history/$(date +%Y-%m-%d).json
+  continue-on-error: true
+```
+Replace it with (uses the real `baseline` command, which writes `.simplicity-baseline.json` next to the solution; `report` then reads `.simplicity-history/*.json` for trends):
+```yaml
+- name: Save snapshot for trends
+  run: |
+    mkdir -p .simplicity-history
+    dotnet simplicity baseline YourSolution.sln
+    cp .simplicity-baseline.json .simplicity-history/$(date +%Y-%m-%d).json
+  continue-on-error: true
+```
+
+- [ ] **Step 3: Verify no `snapshot` command reference survives**
+
+Run:
+```bash
+grep -rn "simplicity snapshot" docs/ README.md | grep -v CODEBASE_REVIEW
+```
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/using-the-simplicity-tools.md
+git commit -m "docs: replace nonexistent 'simplicity snapshot' with real baseline flow"
+```
+
+---
+
+## Task 3: Make README install honest pre-launch and correct the snippets
+
+**Files:**
+- Modify: `README.md` (Quick Install table region ~lines 74-104)
+
+- [ ] **Step 1: Add a pre-launch availability note above the Quick Install table**
+
+In `README.md`, locate the `### ⚡ Quick Install` heading (line ~74). Immediately after that heading line and before the package table, insert:
+```markdown
+> **Availability:** SimplicityTools is not on NuGet.org yet. The install commands and version badges below become valid once the matching release tag (`libraries/vX.Y.Z`, `analyzers/vX.Y.Z`, `cli/vX.Y.Z`) is published. Until then, [build from source](#get-started) or follow the [distribution plan](docs/distribution-plan.md). The badges self-update on first publish.
+```
+
+- [ ] **Step 2: Remove the now-redundant "(when published)" hedge in Get Started**
+
+In `README.md`, find:
+```markdown
+1. **Install the global tool** (when published):
+```
+Replace with:
+```markdown
+1. **Install the global tool** (once published — see [availability](#-quick-install)):
+```
+
+- [ ] **Step 3: Verify the three install snippets match real package IDs / tool name**
+
+Run:
+```bash
+grep -n "dotnet tool install --global SimplicityTools.Cli" README.md   # global tool
+grep -n "dotnet add package SimplicityTools.Metrics" README.md         # libraries
+grep -n 'PrivateAssets="all"' README.md                                # analyzers
+grep -n "dotnet simplicity analyze" README.md                          # invoked command name
+```
+Expected: each grep returns at least one line. (These already exist and are correct; this step confirms the honesty edits did not break them.)
+
+- [ ] **Step 4: Confirm no stray availability contradictions remain**
+
+Run:
+```bash
+grep -n "when published" README.md
+```
+Expected: only the single corrected reference from Step 2 (`once published — see`). No bare "(when published)" remains.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): state pre-launch NuGet availability, link distribution plan"
+```
+
+---
+
+## Task 4: Sweep docs for command/flag accuracy against the real 6-command surface
+
+**Files:**
+- Modify (only if drift found): `docs/quickstart.md`, `docs/using-the-simplicity-tools.md`, `docs/troubleshooting.md`
+
+- [ ] **Step 1: Enumerate every `dotnet simplicity <word>` invocation in docs**
+
+Run:
+```bash
+grep -rhoE "dotnet simplicity [a-z]+" docs/*.md README.md | sort -u
+```
+Expected (allowed) set: `analyze`, `baseline`, `budget`, `diff`, `report`, `watch`. Any other verb (e.g. `snapshot`, `init`, `check`) is drift.
+
+- [ ] **Step 2: Fix any non-allowed verb found**
+
+For each disallowed verb, open the file at the reported location and rewrite the example using the correct real command (see this plan's "Verified facts" for behavior). If Step 1 returns only the six allowed verbs, make no change and note "no command drift found" — skip to Step 4.
+
+- [ ] **Step 3: Spot-check the headline flag `--fail-on-regression` is attached to `diff`**
+
+Run:
+```bash
+grep -rn "fail-on-regression" docs/ README.md
+```
+Expected: every occurrence is on a `dotnet simplicity diff ...` line (this is the gating flag from the README). If any occurrence is attached to a different command, correct it to `diff`.
+
+- [ ] **Step 4: Commit (only if changes were made)**
+
+```bash
+git add -A docs/ README.md
+git commit -m "docs: align command/flag examples with the real CLI surface"
+```
+If Step 2 and Step 3 produced no edits, skip the commit and record "no drift" in the task notes.
+
+---
+
+## Task 5: Write the NuGet distribution plan (`docs/distribution-plan.md`)
+
+**Files:**
+- Create: `docs/distribution-plan.md`
+
+- [ ] **Step 1: Create the file with the full runbook content**
+
+Write `docs/distribution-plan.md` with exactly this content:
+
+````markdown
+# SimplicityTools Distribution Plan
+
+**Status:** First public release of `0.4.0` (never shipped) + ongoing strategy.
+**Audience:** Maintainers/operators cutting releases.
+**Companion:** Pre-publish blockers are tracked in [`CODEBASE_REVIEW_2026-05-28.md`](CODEBASE_REVIEW_2026-05-28.md); release mechanics in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+SimplicityTools ships five NuGet packages in three independently tagged release groups:
+
+| Release group | Tag | Packages |
+| --- | --- | --- |
+| Shared libraries | `libraries/vX.Y.Z` | `SimplicityTools.Metrics`, `SimplicityTools.Filters`, `SimplicityTools.Tca` |
+| Analyzers | `analyzers/vX.Y.Z` | `SimplicityTools.Analyzers` |
+| CLI | `cli/vX.Y.Z` | `SimplicityTools.Cli` (`dotnet-simplicity` global tool) |
+
+The canonical version baseline is `SimplicityToolsReleaseVersion` in `Directory.Build.props` (currently `0.4.0`).
+
+---
+
+## 1. Pre-publish gate (must be GREEN before any real tag)
+
+Treat the 2026-05-28 review's blockers as open. Do not push a stable tag until all pass:
+
+- [ ] Clean build, zero warnings (including CS8604 in Analyzers):
+  `dotnet build SimplicityTools.sln --nologo --verbosity minimal`
+- [ ] Full test suite green (Sample.Simplified baseline, CLI P95 perf gate):
+  `dotnet test SimplicityTools.sln --nologo --no-build --verbosity minimal`
+- [ ] Analyzer package consumer validation: pack, reference from a scratch project with `PrivateAssets="all"`, confirm at least one `SF000x` diagnostic loads and **no** `lib/` compile assets or NuGet dependencies leak downstream.
+- [ ] CLI packaged smoke test: install from a local feed, then
+  `dotnet simplicity analyze ./samples/Sample.Simplified/Sample.Simplified.sln` succeeds.
+- [ ] Docs reconciled: no `simplicity-first.dev` links in `src/` or `docs/`; no `dotnet simplicity snapshot`; README states pre-launch availability.
+
+Go/No-Go: any unchecked box = NO-GO.
+
+## 2. Publishing mechanics
+
+- **Secret:** `NUGET_API_KEY` stored in repo Actions secrets. Use a key scoped to the `SimplicityTools.*` package glob with a finite expiry; rotate after first release.
+- **Version source:** `Directory.Build.props` sets the baseline; the pushed tag's SemVer is authoritative at publish time. Local `dotnet pack` defaults to `<version>-local`.
+- **Tag → publish:** `nuget-publish.yml` reads the SemVer from the tag, validates the matching package group, and publishes `.nupkg` + `.snupkg` to NuGet.org. Branch pushes only produce `-ci.<run>` validation artifacts.
+- **Validation dry-run:** Actions → NuGet release pipeline → Run workflow with `release_group=validation` to exercise pack/validate without publishing.
+- **Prerelease first:** because this is the first-ever publish, ship `0.4.0-preview.1` (or `-rc.1`) per group first to prove the live pipeline and install UX, then the bare `0.4.0` stable.
+
+## 3. User install paths + post-publish smoke tests
+
+### 3.1 Global CLI tool
+```bash
+dotnet tool install --global SimplicityTools.Cli
+dotnet simplicity analyze path/to/YourSolution.sln
+```
+Smoke test after publish: install on a clean machine/container, run `analyze` on `Sample.Simplified`, confirm exit 0 and a metrics summary.
+
+### 3.2 Libraries
+```bash
+dotnet add package SimplicityTools.Metrics   # + Filters / Tca as needed (version together)
+```
+Smoke test: a scratch console app calls `await new SimplicityCollector().CollectAsync("...sln")` and prints `snapshot.ToSummary()`.
+
+### 3.3 Analyzers
+```xml
+<PackageReference Include="SimplicityTools.Analyzers" Version="x.y.z" PrivateAssets="all" />
+```
+Smoke test: build a scratch project that references it and confirm an `SF000x` warning appears in build output, with no added compile/runtime assets in the consumer graph.
+
+## 4. First-release runbook (ordered)
+
+1. Confirm the §1 gate is fully GREEN.
+2. Confirm `SimplicityToolsReleaseVersion` is `0.4.0`.
+3. (Optional) Run the `validation` workflow dispatch; confirm artifacts build.
+4. Push **prerelease** tags, libraries first (dependency root):
+   `git tag libraries/v0.4.0-preview.1 && git push origin libraries/v0.4.0-preview.1`
+   then `analyzers/v0.4.0-preview.1`, then `cli/v0.4.0-preview.1`.
+5. After each publish, verify on NuGet.org and run the matching §3 smoke test.
+6. When prerelease is validated, push **stable** tags in the same order:
+   `libraries/v0.4.0` → `analyzers/v0.4.0` → `cli/v0.4.0`.
+7. Re-run all three smoke tests against the stable packages.
+8. Announce (README badges go live automatically; update CHANGELOG).
+
+## 5. Ongoing strategy
+
+- **SemVer policy:** patch (`x.y.Z`) = additive/safe; minor (`x.Y.z`) = new metrics/rules — evaluate before upgrading; major (`X.y.z`) = breaking API. `Metrics`/`Filters`/`Tca` always version together; `Analyzers` and `Cli` move on their own cadence.
+- **Prerelease channel:** publish `-preview.N`/`-rc.N` for any change touching the published API surface or the analyzer package layout before the stable tag.
+- **Changelog:** maintain `CHANGELOG.md` with one section per release group and version.
+- **Bad publish:** NuGet packages are immutable — never attempt deletion. Unlist the broken version and publish a fixed patch.
+````
+
+- [ ] **Step 2: Verify the file exists and has all five sections**
+
+Run:
+```bash
+grep -nE "^## [1-5]\." docs/distribution-plan.md
+```
+Expected: five headings — `## 1. Pre-publish gate`, `## 2. Publishing mechanics`, `## 3. User install paths`, `## 4. First-release runbook`, `## 5. Ongoing strategy`.
+
+- [ ] **Step 3: Verify the README link target now resolves**
+
+Run:
+```bash
+test -f docs/distribution-plan.md && echo "link target OK"
+```
+Expected: `link target OK` (this is the file `README.md` links to from Task 3 Step 1).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/distribution-plan.md
+git commit -m "docs: add NuGet/dotnet-tool/CLI distribution plan and first-release runbook"
+```
+
+---
+
+## Task 6: Final acceptance verification (spec §5)
+
+**Files:** none (verification only; fix-and-recommit if a check fails)
+
+- [ ] **Step 1: No dead host in code or docs (excluding history + dated review)**
+
+Run:
+```bash
+grep -rn "simplicity-first.dev" src/ docs/ README.md | grep -v "CODEBASE_REVIEW_2026-05-28"
+```
+Expected: no output.
+
+- [ ] **Step 2: No `snapshot` command reference**
+
+Run:
+```bash
+grep -rn "simplicity snapshot" docs/ README.md | grep -v "CODEBASE_REVIEW_2026-05-28"
+```
+Expected: no output.
+
+- [ ] **Step 3: Distribution plan present with runbook + gate**
+
+Run:
+```bash
+grep -c "Go/No-Go" docs/distribution-plan.md          # expect: 1
+grep -c "First-release runbook" docs/distribution-plan.md   # expect: 1
+```
+
+- [ ] **Step 4: Solution still builds (no regression from edits)**
+
+Run:
+```bash
+dotnet build SimplicityTools.sln --nologo --verbosity minimal
+```
+Expected: Build succeeded (pre-existing gated warnings allowed; no NEW errors from doc/link edits).
+
+- [ ] **Step 5: Review the full diff and confirm scope**
+
+Run:
+```bash
+git log --oneline main..HEAD
+git diff --stat main..HEAD
+```
+Expected: commits for Tasks 1–5 (and 4 only if drift was found); changed files limited to the 7 analyzers, `docs/using-the-simplicity-tools.md`, `README.md`, `docs/distribution-plan.md`, and the already-committed spec. Nothing outside the plan's File Structure.
+
+- [ ] **Step 6: Finalize**
+
+Branch `docs/nuget-distribution-plan` is ready. Use the superpowers:finishing-a-development-branch skill to choose merge/PR.
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §3.1 → Task 1; §3.2 → Task 2; §3.3 → Task 3; §3.4 → Task 4; §4.1–4.5 → Task 5; §5 acceptance → Task 6. All spec sections mapped.
+- **Placeholder scan:** No TBD/TODO; every edit step shows exact strings/commands and the full content of the new doc.
+- **Consistency:** README link `docs/distribution-plan.md` (Task 3 Step 1) matches the file created in Task 5 and verified in Task 6 Step 3. Analyzer route casing (`sf000x`, lowercase) is consistent across Task 1 and the verified `docs-site` page files. The `baseline`→`.simplicity-baseline.json`→`.simplicity-history/` flow in Task 2 matches the verified CLI behavior.

--- a/docs/superpowers/specs/2026-06-08-nuget-distribution-design.md
+++ b/docs/superpowers/specs/2026-06-08-nuget-distribution-design.md
@@ -1,0 +1,118 @@
+# SimplicityTools — Documentation Reconciliation & NuGet Distribution Design
+
+**Date:** 2026-06-08
+**Author:** Chris Woodruff (with Claude Code)
+**Status:** Design — pending implementation plan
+**Supersedes:** Nothing. Complements `docs/CODEBASE_REVIEW_2026-05-28.md` (the still-open blocker record).
+
+---
+
+## 1. Purpose of the Solution (Context)
+
+SimplicityTools is a .NET toolkit that measures solution complexity and surfaces simplification opportunities in the IDE and CI/CD. It ships as five independently versioned NuGet packages:
+
+| Package | Role |
+| --- | --- |
+| `SimplicityTools.Metrics` | Core snapshot/collection API (`SimplicityCollector.CollectAsync`) |
+| `SimplicityTools.Filters` | Health-verdict evaluators (TwoAmTest, HalfRule, PrimaryPathFirst) |
+| `SimplicityTools.Tca` | Total-cost-of-complexity estimate |
+| `SimplicityTools.Analyzers` | Seven Roslyn diagnostics (SF0001–SF0007) + two code fixes |
+| `SimplicityTools.Cli` | `dotnet-simplicity` global tool |
+
+Distribution is designed around **tag-driven CI publishing** to NuGet.org, with three release groups: `libraries/vX.Y.Z` (Metrics+Filters+Tca together), `analyzers/vX.Y.Z`, and `cli/vX.Y.Z`. The canonical version baseline lives in `Directory.Build.props` (`SimplicityToolsReleaseVersion`, currently `0.4.0`).
+
+### Verified current state (2026-06-08)
+
+- **Nothing has shipped.** No git tags exist; neither `SimplicityTools.Cli` nor `SimplicityTools.Metrics` resolve on NuGet.org (`BlobNotFound`). Version is pinned at `0.4.0`, never released.
+- **Real CLI command surface:** `analyze`, `report`, `baseline`, `diff`, `budget`, `watch` (6 commands). There is **no** `snapshot` command.
+- **Dead analyzer help links:** All seven analyzers set `helpLinkUri` to `https://simplicity-first.dev/analyzers/SF000X` (404). The live docs site serves `https://simplicitytools.dev/analyzers/sf000x/` (lowercase).
+- **Doc drift:** `docs/using-the-simplicity-tools.md:917` uses the nonexistent `dotnet simplicity snapshot`. README "Quick Install" presents NuGet badges and install commands as if live, hedged only with "(when published)".
+- **Packaging mechanics look correct:** `SimplicityTools.Analyzers.csproj` now packs the DLL into `analyzers/dotnet/cs` via the `PackRoslynAnalyzerArtifacts` target (the review's B4 layout concern appears addressed in csproj; consumer validation in CI still to be confirmed). `nuget-publish.yml` and the tag-driven contract exist but have never been triggered.
+- **Per user direction:** the 2026-05-28 review's blockers are assumed **still open** and are treated as a pre-publish gate, not re-audited here.
+
+---
+
+## 2. Goals
+
+1. **Reconcile docs with reality** (fix drift) and **strengthen distribution-facing docs** (NuGet + dotnet tooling + CLI install/usage).
+2. **Produce a first-public-release runbook** that takes `0.4.0` from never-shipped to live on NuGet.org, plus an **ongoing versioning/cadence strategy**.
+
+Non-goals: re-auditing analyzer logic correctness; redesigning the CLI; broad README restructure beyond the install/distribution surface; fixing the code-side review blockers themselves (they are gated, not solved here).
+
+---
+
+## 3. Deliverable 1 — Documentation & Drift Fixes
+
+### 3.1 Analyzer help links (code)
+Retarget all seven `helpLinkUri` values from `https://simplicity-first.dev/analyzers/SF000X` to `https://simplicitytools.dev/analyzers/sf000x/` (lowercase, trailing slash to match the live routes). Files:
+`SingleImplementationInterfaceAnalyzer.cs` (SF0001), `UnusedDependencyAnalyzer.cs` (SF0002), `HighComplexityAnalyzer.cs` (SF0003), `AbstractionLayerDepthAnalyzer.cs` (SF0004), `ConstructorParameterCountAnalyzer.cs` (SF0005), `SingleSpecializationGenericParameterAnalyzer.cs` (SF0006), `NonPrimaryPathOverReferencedAnalyzer.cs` (SF0007).
+
+Verification: each SF000x route resolves on the live site (or is confirmed to exist in `docs-site`).
+
+### 3.2 Remove the nonexistent `snapshot` command
+`docs/using-the-simplicity-tools.md` (~line 917) shows `cp $(dotnet simplicity snapshot ...)`. Replace with a workflow using the real commands. `baseline` writes the snapshot JSON to a deterministic path (`BaselineSnapshotFile`); rewrite the history-capture example around `baseline` (and/or `report`'s JSON output) so it reflects shipping behavior. Sweep the rest of the doc for any other `snapshot`-as-command usages.
+
+### 3.3 README install honesty + distribution surface
+- Add a clear, prominent status note near "Quick Install": packages are **not yet on NuGet**; install commands become valid once the corresponding `vX.Y.Z` tag is published. Keep the badges (they self-update once live) but ensure surrounding prose does not imply current availability.
+- Tighten the three install paths so each is copy-paste correct against the real package IDs and the `dotnet-simplicity` tool command name:
+  - Global tool: `dotnet tool install --global SimplicityTools.Cli` → invoked as `dotnet simplicity ...`
+  - Libraries: `dotnet add package SimplicityTools.Metrics|Filters|Tca`
+  - Analyzers: `PackageReference ... PrivateAssets="all"`
+- Ensure the command list reflects the real 6 commands (no `snapshot`).
+
+### 3.4 Accurate command reference
+Confirm `docs/using-the-simplicity-tools.md` and `docs/quickstart.md` document exactly the 6 real commands with correct flags (e.g., `diff --fail-on-regression`). Remove or correct any command/flag not present in `Program.cs`. (Scope-limited: fix incorrect/nonexistent items; not a full rewrite.)
+
+---
+
+## 4. Deliverable 2 — NuGet Distribution Plan (new doc)
+
+A standalone runbook written to `docs/distribution-plan.md` (user-facing/operator doc, distinct from this spec). Structure:
+
+### 4.1 Pre-publish gate (blockers must pass)
+A checklist derived from `CODEBASE_REVIEW_2026-05-28.md`, treated as still-open:
+- [ ] `dotnet build SimplicityTools.sln` — 0 warnings (incl. CS8604 in Analyzers)
+- [ ] `dotnet test SimplicityTools.sln` — all green (Sample.Simplified baseline, CLI P95 perf gate)
+- [ ] Analyzer package consumer validation: pack → reference from scratch project → confirm an `SF000x` diagnostic loads and no `lib/` compile assets / NuGet deps leak
+- [ ] CLI packaged smoke test: install from local feed → `dotnet simplicity analyze` on `Sample.Simplified`
+- [ ] Doc drift fixed (Deliverable 1 merged; no dead `simplicity-first.dev` links, no `snapshot` command)
+
+The gate is a hard go/no-go before any real tag is pushed.
+
+### 4.2 Publishing mechanics
+- **Secrets:** `NUGET_API_KEY` configured in repo secrets; scope and expiry noted.
+- **Release groups & tags:** `libraries/vX.Y.Z`, `analyzers/vX.Y.Z`, `cli/vX.Y.Z` — what each publishes and why libraries move together.
+- **Version source:** `Directory.Build.props` `SimplicityToolsReleaseVersion`; tag SemVer authoritative at publish.
+- **Prerelease vs stable:** recommend a `0.4.0-preview.N` (or `-rc.N`) first push to validate the full pipeline against NuGet.org before the bare `0.4.0` stable, since this is the first-ever publish.
+- **Validation-only dispatch:** `release_group=validation` workflow path for dry runs.
+
+### 4.3 Three user install paths (with post-publish smoke tests)
+For each: install command, minimal usage, and a verification step that proves the published artifact works:
+1. **Global tool** — `dotnet tool install --global SimplicityTools.Cli`; verify `dotnet simplicity analyze`.
+2. **Libraries** — `dotnet add package`; verify `SimplicityCollector.CollectAsync` compiles/runs in a scratch consumer.
+3. **Analyzers** — `PackageReference PrivateAssets="all"`; verify a diagnostic surfaces and the package contributes no compile/runtime assets downstream.
+
+### 4.4 First-release runbook (ordered)
+Exact steps: confirm gate green → bump/confirm version → optional GitHub Actions validation dispatch → push prerelease tag(s) → verify on NuGet.org + run the three smoke tests → push stable tag(s) → re-verify → announce. Recommended order: `libraries` first (dependency root), then `analyzers` and `cli`.
+
+### 4.5 Ongoing strategy
+- **Cadence & SemVer policy:** patch = additive/safe; minor = new metrics/rules (evaluate); major = breaking API. Restate the libraries-version-together rule.
+- **Prerelease channel:** when to ship `-preview`/`-rc`.
+- **Changelog:** introduce `CHANGELOG.md` keyed to release groups.
+- **Yank/deprecate policy:** how to handle a bad publish (NuGet unlist, not delete).
+
+---
+
+## 5. Acceptance Criteria
+
+- No reference to `simplicity-first.dev` remains in `src/` or `docs/` (excluding `.squad/` history and the dated review).
+- No reference to a `dotnet simplicity snapshot` command remains in `docs/` or `README.md`.
+- README clearly states pre-launch availability and all three install snippets are copy-paste correct.
+- `docs/distribution-plan.md` exists with all five sections (4.1–4.5), including a green/red pre-publish gate and an ordered first-release runbook with verification commands.
+- This spec, the doc fixes, and the new plan are committed.
+
+## 6. Out of Scope
+- Fixing the code-side review blockers (tests, warnings, perf gate) — gated, executed separately.
+- Re-auditing analyzer logic vs. docs (review item F1).
+- Wiring `simplicity.json` config end-to-end (review item F2).
+- Full README restructure / role-based navigation beyond the install surface.

--- a/docs/using-the-simplicity-tools.md
+++ b/docs/using-the-simplicity-tools.md
@@ -914,7 +914,8 @@ To keep a trend report across builds, save historical snapshots:
 - name: Save snapshot for trends
   run: |
     mkdir -p .simplicity-history
-    cp $(dotnet simplicity snapshot YourSolution.sln) .simplicity-history/$(date +%Y-%m-%d).json
+    dotnet simplicity baseline YourSolution.sln
+    cp .simplicity-baseline.json .simplicity-history/$(date +%Y-%m-%d).json
   continue-on-error: true
 
 - name: Generate trend report

--- a/src/SimplicityTools.Analyzers/AbstractionLayerDepthAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/AbstractionLayerDepthAnalyzer.cs
@@ -19,7 +19,7 @@ public sealed class AbstractionLayerDepthAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.PrimaryPathFirst,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicity-first.dev/analyzers/SF0004",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0004",
         description: "Long source-level call chains hide the primary path behind wrappers and indirection.",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 

--- a/src/SimplicityTools.Analyzers/AbstractionLayerDepthAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/AbstractionLayerDepthAnalyzer.cs
@@ -19,7 +19,7 @@ public sealed class AbstractionLayerDepthAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.PrimaryPathFirst,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0004",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0004/",
         description: "Long source-level call chains hide the primary path behind wrappers and indirection.",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 

--- a/src/SimplicityTools.Analyzers/ConstructorParameterCountAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/ConstructorParameterCountAnalyzer.cs
@@ -18,7 +18,7 @@ public sealed class ConstructorParameterCountAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.TwoAmTest,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0005",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0005/",
         description: "Large constructor parameter lists are a strong signal that a type is doing too much.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];

--- a/src/SimplicityTools.Analyzers/ConstructorParameterCountAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/ConstructorParameterCountAnalyzer.cs
@@ -18,7 +18,7 @@ public sealed class ConstructorParameterCountAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.TwoAmTest,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicity-first.dev/analyzers/SF0005",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0005",
         description: "Large constructor parameter lists are a strong signal that a type is doing too much.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];

--- a/src/SimplicityTools.Analyzers/HighComplexityAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/HighComplexityAnalyzer.cs
@@ -19,7 +19,7 @@ public sealed class HighComplexityAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.TwoAmTest,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicity-first.dev/analyzers/SF0003",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0003",
         description: "Methods that exceed the agreed cyclomatic complexity threshold are hard to reason about under pressure.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];

--- a/src/SimplicityTools.Analyzers/HighComplexityAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/HighComplexityAnalyzer.cs
@@ -19,7 +19,7 @@ public sealed class HighComplexityAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.TwoAmTest,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0003",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0003/",
         description: "Methods that exceed the agreed cyclomatic complexity threshold are hard to reason about under pressure.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];

--- a/src/SimplicityTools.Analyzers/NonPrimaryPathOverReferencedAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/NonPrimaryPathOverReferencedAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class NonPrimaryPathOverReferencedAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.PrimaryPathFirst,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicity-first.dev/analyzers/SF0007",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0007",
         description: "When supporting files become more referenced than primary-path files, the real business flow is no longer obvious.",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 

--- a/src/SimplicityTools.Analyzers/NonPrimaryPathOverReferencedAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/NonPrimaryPathOverReferencedAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class NonPrimaryPathOverReferencedAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.PrimaryPathFirst,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0007",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0007/",
         description: "When supporting files become more referenced than primary-path files, the real business flow is no longer obvious.",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 

--- a/src/SimplicityTools.Analyzers/SingleImplementationInterfaceAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/SingleImplementationInterfaceAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class SingleImplementationInterfaceAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.HalfRule,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0001",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0001/",
         description: "Interfaces with a single concrete implementation add indirection without buying polymorphism.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];

--- a/src/SimplicityTools.Analyzers/SingleImplementationInterfaceAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/SingleImplementationInterfaceAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class SingleImplementationInterfaceAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.HalfRule,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicity-first.dev/analyzers/SF0001",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0001",
         description: "Interfaces with a single concrete implementation add indirection without buying polymorphism.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];

--- a/src/SimplicityTools.Analyzers/SingleSpecializationGenericParameterAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/SingleSpecializationGenericParameterAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class SingleSpecializationGenericParameterAnalyzer : DiagnosticAna
         category: AnalyzerCategories.HalfRule,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0006",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0006/",
         description: "A generic parameter that is only ever bound to one concrete type is indirection without flexibility.",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 

--- a/src/SimplicityTools.Analyzers/SingleSpecializationGenericParameterAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/SingleSpecializationGenericParameterAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class SingleSpecializationGenericParameterAnalyzer : DiagnosticAna
         category: AnalyzerCategories.HalfRule,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicity-first.dev/analyzers/SF0006",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0006",
         description: "A generic parameter that is only ever bound to one concrete type is indirection without flexibility.",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 

--- a/src/SimplicityTools.Analyzers/UnusedDependencyAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/UnusedDependencyAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class UnusedDependencyAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.HalfRule,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0002",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0002/",
         description: "Package references that contribute no used symbols add restore time and maintenance overhead without value.",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 

--- a/src/SimplicityTools.Analyzers/UnusedDependencyAnalyzer.cs
+++ b/src/SimplicityTools.Analyzers/UnusedDependencyAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class UnusedDependencyAnalyzer : DiagnosticAnalyzer
         category: AnalyzerCategories.HalfRule,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://simplicity-first.dev/analyzers/SF0002",
+        helpLinkUri: "https://simplicitytools.dev/analyzers/sf0002",
         description: "Package references that contribute no used symbols add restore time and maintenance overhead without value.",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 


### PR DESCRIPTION
## Summary

Reconciles SimplicityTools' docs/code with shipping reality and adds a first-public-release distribution runbook. Context: despite the README's install badges, **nothing has shipped** — no git tags, packages not on NuGet.org, version pinned at `0.4.0`.

**Drift fixes (docs match reality):**
- Retargeted all 7 analyzer help links (`SF0001`–`SF0007`) from the dead `simplicity-first.dev/analyzers/SF000X` to the live `simplicitytools.dev/analyzers/sf000x/` (lowercase + trailing slash, matching the Astro `trailingSlash: 'always'` config).
- Replaced the nonexistent `dotnet simplicity snapshot` command in `using-the-simplicity-tools.md` with the real `baseline` → `.simplicity-baseline.json` → `.simplicity-history/` flow.
- README now states pre-launch NuGet availability honestly and links the new distribution plan.
- Aligned the historical AI-implementation doc (which still said "404 is acceptable in v1") with the now-live pages.

**New deliverable — `docs/distribution-plan.md`:**
- Pre-publish gate (the still-open 2026-05-28 review blockers as a hard Go/No-Go checklist)
- Publishing mechanics (NuGet API key, the 3 tag groups, prerelease-first)
- Three install paths (global tool / libraries / analyzers) each with a post-publish smoke test
- Ordered first-release runbook for 0.4.0 (libraries first, prerelease then stable)
- Ongoing versioning/cadence/changelog/yank strategy

Also includes the design spec and implementation plan under `docs/superpowers/`.

## Test Plan
- [x] `dotnet build` of the Analyzers project — 0 errors (5 pre-existing CS8604 warnings are the review's gated B2 blocker, untouched here)
- [x] No `simplicity-first.dev` links remain in `src/` or `docs/` (excl. dated review/history)
- [x] No `dotnet simplicity snapshot` references in user docs
- [x] All 7 help-link URLs verified to carry the trailing slash required by the live site
- [x] Command/flag sweep confirms only the 6 real commands (`analyze`, `report`, `baseline`, `diff`, `budget`, `watch`) appear in user docs
- [ ] Reviewer to confirm the 7 live `simplicitytools.dev/analyzers/sf000x/` pages resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)